### PR TITLE
Validate result returned to QML API models

### DIFF
--- a/src/rrcore/models/abstracthomemodel.cpp
+++ b/src/rrcore/models/abstracthomemodel.cpp
@@ -21,6 +21,17 @@ QVariantList AbstractHomeModel::records() const
     return m_records;
 }
 
+void AbstractHomeModel::tryQuery()
+{
+
+}
+
+bool AbstractHomeModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
 int AbstractHomeModel::rowCount(const QModelIndex &parent) const
 {
     if (parent.isValid())
@@ -68,7 +79,7 @@ QHash<int, QByteArray> AbstractHomeModel::roleNames() const
     };
 }
 
-void AbstractHomeModel::processResult(const QueryResult result)
+void AbstractHomeModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/models/abstracthomemodel.h
+++ b/src/rrcore/models/abstracthomemodel.h
@@ -29,7 +29,9 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 protected:
     QVariantList records() const;
-    void processResult(const QueryResult result) override;
+    void tryQuery() override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override;
 private:
     QVariantList m_records;
 };

--- a/src/rrcore/models/abstractvisuallistmodel.cpp
+++ b/src/rrcore/models/abstractvisuallistmodel.cpp
@@ -189,6 +189,17 @@ Utility::SortCriteria AbstractVisualListModel::sortCriteria() const
     return m_sortCriteria;
 }
 
+void AbstractVisualListModel::validateResult(const QueryResult result)
+{
+    if (canProcessResult(result))
+        processResult(result);
+    else
+        qFatal("Validation failed for %s.\nActual returned keys: %s.\nExpected returned keys: %s",
+               result.request().command().toStdString().c_str(),
+               result.outcome().toMap().keys().join(", ").toStdString().c_str(),
+               result.errorDetails().toStdString().c_str());
+}
+
 void AbstractVisualListModel::refresh()
 {
     tryQuery();

--- a/src/rrcore/models/abstractvisuallistmodel.h
+++ b/src/rrcore/models/abstractvisuallistmodel.h
@@ -57,7 +57,8 @@ public slots:
     virtual void refresh();
 protected:
     virtual void tryQuery() = 0;
-    virtual void processResult(const QueryResult result) = 0;
+    virtual bool canProcessResult(const QueryResult &result) const = 0;
+    virtual void processResult(const QueryResult &result) = 0;
     virtual void filter();
     virtual QString columnName(int column) const;
     const QueryRequest &lastSuccessfulRequest() const;
@@ -85,6 +86,7 @@ private:
     Utility::SortCriteria m_sortCriteria;
     QueryRequest m_lastSuccessfulRequest;
 
+    void validateResult(const QueryResult result);
     void saveRequest(const QueryResult &result);
 };
 

--- a/src/rrcore/models/abstractvisualtablemodel.h
+++ b/src/rrcore/models/abstractvisualtablemodel.h
@@ -62,7 +62,8 @@ public slots:
     virtual void refresh();
 protected:
     virtual void tryQuery() = 0;
-    virtual void processResult(const QueryResult result) = 0;
+    virtual bool canProcessResult(const QueryResult &result) const = 0;
+    virtual void processResult(const QueryResult &result) = 0;
     virtual QString columnName(int column) const;
     virtual void filter();
     void setBusy(bool);
@@ -92,6 +93,7 @@ private:
     double m_tableViewWidth {0.0};
     QueryRequest m_lastSuccessfulRequest;
 
+    void validateResult(const QueryResult result);
     void saveRequest(const QueryResult &result);
 };
 

--- a/src/rrcore/models/purchasepaymentmodel.cpp
+++ b/src/rrcore/models/purchasepaymentmodel.cpp
@@ -109,7 +109,13 @@ void PurchasePaymentModel::tryQuery()
 
 }
 
-void PurchasePaymentModel::processResult(const QueryResult result)
+bool PurchasePaymentModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void PurchasePaymentModel::processResult(const QueryResult &result)
 {
     Q_UNUSED(result)
 }

--- a/src/rrcore/models/purchasepaymentmodel.h
+++ b/src/rrcore/models/purchasepaymentmodel.h
@@ -31,7 +31,8 @@ public:
     void calculatePaymentCount();
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override;
 signals:
     void cashPaymentCountChanged();
     void cardPaymentCountChanged();

--- a/src/rrcore/models/receiptcartmodel.cpp
+++ b/src/rrcore/models/receiptcartmodel.cpp
@@ -81,7 +81,13 @@ void ReceiptCartModel::tryQuery()
 
 }
 
-void ReceiptCartModel::processResult(const QueryResult result)
+bool ReceiptCartModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void ReceiptCartModel::processResult(const QueryResult &result)
 {
     Q_UNUSED(result)
 }

--- a/src/rrcore/models/receiptcartmodel.h
+++ b/src/rrcore/models/receiptcartmodel.h
@@ -35,7 +35,8 @@ public:
     QString paymentType() const;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override final;
     QString columnName(int column) const override final;
 private:
     QVariantList m_records;

--- a/src/rrcore/models/salemostsoldproductmodel.cpp
+++ b/src/rrcore/models/salemostsoldproductmodel.cpp
@@ -79,7 +79,13 @@ void SaleMostSoldProductModel::tryQuery()
 
 }
 
-void SaleMostSoldProductModel::processResult(const QueryResult result)
+bool SaleMostSoldProductModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void SaleMostSoldProductModel::processResult(const QueryResult &result)
 {
     Q_UNUSED(result)
 }

--- a/src/rrcore/models/salemostsoldproductmodel.h
+++ b/src/rrcore/models/salemostsoldproductmodel.h
@@ -28,7 +28,8 @@ public:
     QHash<int, QByteArray> roleNames() const override final;
 protected:
     void tryQuery() override final;
-    void processResult(const QueryResult result) override final;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override final;
 private:
     QVariantList m_records;
 };

--- a/src/rrcore/models/salepaymentmodel.cpp
+++ b/src/rrcore/models/salepaymentmodel.cpp
@@ -111,7 +111,13 @@ void SalePaymentModel::tryQuery()
 
 }
 
-void SalePaymentModel::processResult(const QueryResult result)
+bool SalePaymentModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void SalePaymentModel::processResult(const QueryResult &result)
 {
     Q_UNUSED(result)
 }

--- a/src/rrcore/models/salepaymentmodel.h
+++ b/src/rrcore/models/salepaymentmodel.h
@@ -35,7 +35,8 @@ public:
     void calculatePaymentCount();
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override;
 signals:
     void cashPaymentCountChanged();
     void cardPaymentCountChanged();

--- a/src/rrcore/models/saletotalrevenuemodel.cpp
+++ b/src/rrcore/models/saletotalrevenuemodel.cpp
@@ -60,7 +60,13 @@ void SaleTotalRevenueModel::tryQuery()
 
 }
 
-void SaleTotalRevenueModel::processResult(const QueryResult result)
+bool SaleTotalRevenueModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void SaleTotalRevenueModel::processResult(const QueryResult &result)
 {
     Q_UNUSED(result)
 }

--- a/src/rrcore/models/saletotalrevenuemodel.h
+++ b/src/rrcore/models/saletotalrevenuemodel.h
@@ -22,7 +22,8 @@ public:
     QHash<int, QByteArray> roleNames() const override final;
 protected:
     void tryQuery() override final;
-    void processResult(const QueryResult result) override final;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override final;
 private:
     QVariantList m_records;
 };

--- a/src/rrcore/models/userprivilegemodel.cpp
+++ b/src/rrcore/models/userprivilegemodel.cpp
@@ -103,7 +103,13 @@ void UserPrivilegeModel::tryQuery()
 
 }
 
-void UserPrivilegeModel::processResult(const QueryResult result)
+bool UserPrivilegeModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void UserPrivilegeModel::processResult(const QueryResult &result)
 {
     Q_UNUSED(result)
 }

--- a/src/rrcore/models/userprivilegemodel.h
+++ b/src/rrcore/models/userprivilegemodel.h
@@ -28,7 +28,8 @@ public:
     QVariantList privileges() const;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override;
 private:
     QVariantList m_records;
     QString m_privilegeGroup;

--- a/src/rrcore/qmlapi/qmlclientmodel.cpp
+++ b/src/rrcore/qmlapi/qmlclientmodel.cpp
@@ -53,7 +53,13 @@ void QMLClientModel::tryQuery()
     emit execute(new ClientQuery::ViewClients(this));
 }
 
-void QMLClientModel::processResult(const QueryResult result)
+bool QMLClientModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLClientModel::processResult(const QueryResult &result)
 {
     if (result.request().receiver() != this)
         return;

--- a/src/rrcore/qmlapi/qmlclientmodel.h
+++ b/src/rrcore/qmlapi/qmlclientmodel.h
@@ -31,7 +31,8 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override final;
     void filter() override final;
     QString columnName(int column) const override;
 private:

--- a/src/rrcore/qmlapi/qmlcreditormodel.cpp
+++ b/src/rrcore/qmlapi/qmlcreditormodel.cpp
@@ -38,7 +38,13 @@ void QMLCreditorModel::tryQuery()
 
 }
 
-void QMLCreditorModel::processResult(const QueryResult result)
+bool QMLCreditorModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLCreditorModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlcreditormodel.h
+++ b/src/rrcore/qmlapi/qmlcreditormodel.h
@@ -43,7 +43,8 @@ public:
     QHash<int, QByteArray> roleNames() const override final;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override;
 };
 
 #endif // QMLCREDITORMODEL_H

--- a/src/rrcore/qmlapi/qmldebtormodel.cpp
+++ b/src/rrcore/qmlapi/qmldebtormodel.cpp
@@ -74,7 +74,13 @@ void QMLDebtorModel::tryQuery()
     emit execute(new DebtorQuery::ViewDebtors(this));
 }
 
-void QMLDebtorModel::processResult(const QueryResult result)
+bool QMLDebtorModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLDebtorModel::processResult(const QueryResult &result)
 {
     if (result.request().receiver() != this)
         return;

--- a/src/rrcore/qmlapi/qmldebtormodel.h
+++ b/src/rrcore/qmlapi/qmldebtormodel.h
@@ -45,7 +45,8 @@ public:
     Q_INVOKABLE void removeDebtor(int row);
 protected:
     void tryQuery() override final;
-    void processResult(const QueryResult result) override final;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override final;
     void filter() override final;
     QString columnName(int column) const override final;
 public slots:

--- a/src/rrcore/qmlapi/qmldebtpaymentmodel.cpp
+++ b/src/rrcore/qmlapi/qmldebtpaymentmodel.cpp
@@ -208,7 +208,13 @@ void QMLDebtPaymentModel::tryQuery()
                                                    this));
 }
 
-void QMLDebtPaymentModel::processResult(const QueryResult result)
+bool QMLDebtPaymentModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLDebtPaymentModel::processResult(const QueryResult &result)
 {
     if (result.request().receiver() != this)
         return;

--- a/src/rrcore/qmlapi/qmldebtpaymentmodel.h
+++ b/src/rrcore/qmlapi/qmldebtpaymentmodel.h
@@ -54,7 +54,8 @@ signals:
     void totalAmountPaidChanged();
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override;
 private:
     int m_debtTransactionId {0};
     Utility::Money m_totalAmountPaid;

--- a/src/rrcore/qmlapi/qmldebttransactionmodel.cpp
+++ b/src/rrcore/qmlapi/qmldebttransactionmodel.cpp
@@ -257,7 +257,13 @@ void QMLDebtTransactionModel::tryQuery()
     emit execute(new DebtorQuery::ViewDebtTransactions(m_debtor, this));
 }
 
-void QMLDebtTransactionModel::processResult(const QueryResult result)
+bool QMLDebtTransactionModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLDebtTransactionModel::processResult(const QueryResult &result)
 {
     if (result.request().receiver() != this)
         return;

--- a/src/rrcore/qmlapi/qmldebttransactionmodel.h
+++ b/src/rrcore/qmlapi/qmldebttransactionmodel.h
@@ -99,7 +99,8 @@ signals:
     void clientIdChanged();
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
 private:
     bool m_dirty {false};
     Utility::Debtor m_debtor;

--- a/src/rrcore/qmlapi/qmlexpensereportmodel.cpp
+++ b/src/rrcore/qmlapi/qmlexpensereportmodel.cpp
@@ -89,7 +89,13 @@ void QMLExpenseReportModel::tryQuery()
                                                      this));
 }
 
-void QMLExpenseReportModel::processResult(const QueryResult result)
+bool QMLExpenseReportModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLExpenseReportModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlexpensereportmodel.h
+++ b/src/rrcore/qmlapi/qmlexpensereportmodel.h
@@ -31,7 +31,8 @@ public:
                         int role = Qt::DisplayRole) const override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
 private:
     Utility::ExpenseReportTransactionList m_transactions;
 };

--- a/src/rrcore/qmlapi/qmlexpensetransactionmodel.cpp
+++ b/src/rrcore/qmlapi/qmlexpensetransactionmodel.cpp
@@ -105,7 +105,13 @@ void QMLExpenseTransactionModel::tryQuery()
                                                            this));
 }
 
-void QMLExpenseTransactionModel::processResult(const QueryResult result)
+bool QMLExpenseTransactionModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLExpenseTransactionModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlexpensetransactionmodel.h
+++ b/src/rrcore/qmlapi/qmlexpensetransactionmodel.h
@@ -39,7 +39,8 @@ public:
                         int role = Qt::DisplayRole) const override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override;
 private:
     Utility::ExpenseTransactionList m_transactions;
 };

--- a/src/rrcore/qmlapi/qmlincomereportmodel.cpp
+++ b/src/rrcore/qmlapi/qmlincomereportmodel.cpp
@@ -88,7 +88,13 @@ void QMLIncomeReportModel::tryQuery()
                                                    this));
 }
 
-void QMLIncomeReportModel::processResult(const QueryResult result)
+bool QMLIncomeReportModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLIncomeReportModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlincomereportmodel.h
+++ b/src/rrcore/qmlapi/qmlincomereportmodel.h
@@ -31,7 +31,8 @@ public:
                         int role = Qt::DisplayRole) const override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
 private:
     Utility::IncomeReportTransactionList m_transactions;
 };

--- a/src/rrcore/qmlapi/qmlincometransactionmodel.cpp
+++ b/src/rrcore/qmlapi/qmlincometransactionmodel.cpp
@@ -105,7 +105,13 @@ void QMLIncomeTransactionModel::tryQuery()
                                                          this));
 }
 
-void QMLIncomeTransactionModel::processResult(const QueryResult result)
+bool QMLIncomeTransactionModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLIncomeTransactionModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlincometransactionmodel.h
+++ b/src/rrcore/qmlapi/qmlincometransactionmodel.h
@@ -38,7 +38,8 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
 private:
     Utility::IncomeTransactionList m_transactions;
 };

--- a/src/rrcore/qmlapi/qmlpurchasecartmodel.cpp
+++ b/src/rrcore/qmlapi/qmlpurchasecartmodel.cpp
@@ -330,7 +330,13 @@ void QMLPurchaseCartModel::tryQuery()
     }
 }
 
-void QMLPurchaseCartModel::processResult(const QueryResult result)
+bool QMLPurchaseCartModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLPurchaseCartModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlpurchasecartmodel.h
+++ b/src/rrcore/qmlapi/qmlpurchasecartmodel.h
@@ -108,7 +108,8 @@ public:
     Q_INVOKABLE QString toPrintableFormat() const;
 protected:
     void tryQuery() override final;
-    void processResult(const QueryResult result) override final;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
 signals:
     void transactionIdChanged();
     void customerNameChanged();

--- a/src/rrcore/qmlapi/qmlpurchasereportmodel.cpp
+++ b/src/rrcore/qmlapi/qmlpurchasereportmodel.cpp
@@ -106,7 +106,13 @@ void QMLPurchaseReportModel::tryQuery()
                                                        this));
 }
 
-void QMLPurchaseReportModel::processResult(const QueryResult result)
+bool QMLPurchaseReportModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLPurchaseReportModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlpurchasereportmodel.h
+++ b/src/rrcore/qmlapi/qmlpurchasereportmodel.h
@@ -36,7 +36,8 @@ public:
                         int role = Qt::DisplayRole) const override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
 private:
     Utility::PurchaseReportTransactionList m_transactions;
 };

--- a/src/rrcore/qmlapi/qmlpurchasetransactionitemmodel.cpp
+++ b/src/rrcore/qmlapi/qmlpurchasetransactionitemmodel.cpp
@@ -6,6 +6,8 @@
 #include "utility/purchaseutils.h"
 #include <QDateTime>
 
+Q_LOGGING_CATEGORY(lcpurchasetransactionitemmodel, "rrcore.qmlapi.qmlpurchasetransactionitemmodel", QtWarningMsg);
+
 QMLPurchaseTransactionItemModel::QMLPurchaseTransactionItemModel(QObject *parent) :
     QMLPurchaseTransactionItemModel(DatabaseThread::instance(), parent)
 {}
@@ -55,9 +57,9 @@ QVariant QMLPurchaseTransactionItemModel::data(const QModelIndex &index, int rol
     case UnitRole:
         return m_products.at(index.row()).product.unit.unit;
     case CostRole:
-        return m_products.at(index.row()).cost;
+        return m_products.at(index.row()).monies.cost.toDouble();
     case DiscountRole:
-        return m_products.at(index.row()).discount;
+        return m_products.at(index.row()).monies.discount.toDouble();
     case NoteIdRole:
         return m_products.at(index.row()).note.id;
     case NoteRole:
@@ -67,9 +69,9 @@ QVariant QMLPurchaseTransactionItemModel::data(const QModelIndex &index, int rol
     case ArchivedRole:
         return m_products.at(index.row()).flags.testFlag(Utility::RecordGroup::Archived);
     case CreatedRole:
-        return m_products.at(index.row()).created;
+        return m_products.at(index.row()).timestamp.created;
     case LastEditedRole:
-        return m_products.at(index.row()).lastEdited;
+        return m_products.at(index.row()).timestamp.lastEdited;
     case UserIdRole:
         return m_products.at(index.row()).user.id;
     case UserRole:
@@ -159,7 +161,13 @@ void QMLPurchaseTransactionItemModel::tryQuery()
                                                           this));
 }
 
-void QMLPurchaseTransactionItemModel::processResult(const QueryResult result)
+bool QMLPurchaseTransactionItemModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLPurchaseTransactionItemModel::processResult(const QueryResult &result)
 {
     if (result.request().receiver() != this)
         return;
@@ -194,6 +202,7 @@ QString QMLPurchaseTransactionItemModel::columnName(int column) const
         return QStringLiteral("cost");
     }
 
+    qCWarning(lcpurchasetransactionitemmodel) << "Invalid column:" << column;
     return QString();
 }
 

--- a/src/rrcore/qmlapi/qmlpurchasetransactionitemmodel.h
+++ b/src/rrcore/qmlapi/qmlpurchasetransactionitemmodel.h
@@ -3,6 +3,7 @@
 
 #include "models/abstracttransactionitemmodel.h"
 #include "utility/purchase/purchasedproduct.h"
+#include <QLoggingCategory>
 
 class QMLPurchaseTransactionItemModel : public AbstractTransactionItemModel
 {
@@ -54,10 +55,12 @@ public:
     Q_INVOKABLE void removeSoldProduct(int row);
 protected:
     void tryQuery() override final;
-    void processResult(const QueryResult result) override final;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
     QString columnName(int column) const override;
 private:
     Utility::PurchasedProductList m_products;
 };
+Q_DECLARE_LOGGING_CATEGORY(lcpurchasetransactionitemmodel);
 
 #endif // QMLPURCHASETRANSACTIONITEMMODEL_H

--- a/src/rrcore/qmlapi/qmlpurchasetransactionmodel.cpp
+++ b/src/rrcore/qmlapi/qmlpurchasetransactionmodel.cpp
@@ -147,7 +147,13 @@ void QMLPurchaseTransactionModel::tryQuery()
                                                              this));
 }
 
-void QMLPurchaseTransactionModel::processResult(const QueryResult result)
+bool QMLPurchaseTransactionModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLPurchaseTransactionModel::processResult(const QueryResult &result)
 {
     if (result.request().receiver() != this)
         return;

--- a/src/rrcore/qmlapi/qmlpurchasetransactionmodel.h
+++ b/src/rrcore/qmlapi/qmlpurchasetransactionmodel.h
@@ -59,7 +59,8 @@ public:
                         int role = Qt::DisplayRole) const override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
 public slots:
     void removeTransaction(int row);
 private:

--- a/src/rrcore/qmlapi/qmlsalecartmodel.cpp
+++ b/src/rrcore/qmlapi/qmlsalecartmodel.cpp
@@ -341,7 +341,13 @@ void QMLSaleCartModel::tryQuery()
     }
 }
 
-void QMLSaleCartModel::processResult(const QueryResult result)
+bool QMLSaleCartModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLSaleCartModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlsalecartmodel.h
+++ b/src/rrcore/qmlapi/qmlsalecartmodel.h
@@ -113,7 +113,8 @@ public:
     Q_INVOKABLE QString toPrintableFormat() const;
 protected:
     void tryQuery() override final;
-    void processResult(const QueryResult result) override final;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
     void undoLastCommit() override;
 signals:
     void transactionIdChanged();

--- a/src/rrcore/qmlapi/qmlsalehomemodel.cpp
+++ b/src/rrcore/qmlapi/qmlsalehomemodel.cpp
@@ -54,7 +54,13 @@ void QMLSaleHomeModel::tryQuery()
     emit execute(new SaleQuery::ViewSaleHome(this));
 }
 
-void QMLSaleHomeModel::processResult(const QueryResult result)
+bool QMLSaleHomeModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLSaleHomeModel::processResult(const QueryResult &result)
 {
     if (result.request().receiver() != this)
         return;

--- a/src/rrcore/qmlapi/qmlsalehomemodel.h
+++ b/src/rrcore/qmlapi/qmlsalehomemodel.h
@@ -23,7 +23,8 @@ public:
     QHash<int, QByteArray> roleNames() const override final;
 protected:
     virtual void tryQuery() override final;
-    virtual void processResult(const QueryResult result) override final;
+    virtual bool canProcessResult(const QueryResult &result) const override final;
+    virtual void processResult(const QueryResult &result) override final;
 private:
     QVariantList m_records;
     QList<AbstractVisualListModel *> m_dataModels;

--- a/src/rrcore/qmlapi/qmlsalereportmodel.cpp
+++ b/src/rrcore/qmlapi/qmlsalereportmodel.cpp
@@ -109,7 +109,13 @@ void QMLSaleReportModel::tryQuery()
                                                this));
 }
 
-void QMLSaleReportModel::processResult(const QueryResult result)
+bool QMLSaleReportModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLSaleReportModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlsalereportmodel.h
+++ b/src/rrcore/qmlapi/qmlsalereportmodel.h
@@ -34,7 +34,8 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
 private:
     Utility::SaleReportTransactionList m_transactions;
 };

--- a/src/rrcore/qmlapi/qmlsaletransactionitemmodel.cpp
+++ b/src/rrcore/qmlapi/qmlsaletransactionitemmodel.cpp
@@ -160,7 +160,13 @@ void QMLSaleTransactionItemModel::tryQuery()
                                                  this));
 }
 
-void QMLSaleTransactionItemModel::processResult(const QueryResult result)
+bool QMLSaleTransactionItemModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLSaleTransactionItemModel::processResult(const QueryResult &result)
 {
     if (result.request().receiver() != this)
         return;

--- a/src/rrcore/qmlapi/qmlsaletransactionitemmodel.h
+++ b/src/rrcore/qmlapi/qmlsaletransactionitemmodel.h
@@ -51,7 +51,8 @@ public:
                         int role = Qt::DisplayRole) const override;
 protected:
     void tryQuery() override final;
-    void processResult(const QueryResult result) override final;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
     QString columnName(int column) const override;
 private:
     Utility::SoldProductList m_products;

--- a/src/rrcore/qmlapi/qmlsaletransactionmodel.cpp
+++ b/src/rrcore/qmlapi/qmlsaletransactionmodel.cpp
@@ -151,7 +151,13 @@ void QMLSaleTransactionModel::tryQuery()
                                                      this));
 }
 
-void QMLSaleTransactionModel::processResult(const QueryResult result)
+bool QMLSaleTransactionModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLSaleTransactionModel::processResult(const QueryResult &result)
 {
     if (result.request().receiver() != this)
         return;

--- a/src/rrcore/qmlapi/qmlsaletransactionmodel.h
+++ b/src/rrcore/qmlapi/qmlsaletransactionmodel.h
@@ -59,7 +59,8 @@ public:
                         int role = Qt::DisplayRole) const override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override;
 private:
     Utility::SaleTransactionList m_transactions;
 };

--- a/src/rrcore/qmlapi/qmlstockproductcategorymodel.cpp
+++ b/src/rrcore/qmlapi/qmlstockproductcategorymodel.cpp
@@ -193,7 +193,13 @@ void QMLStockProductCategoryModel::tryQuery()
     }
 }
 
-void QMLStockProductCategoryModel::processResult(const QueryResult result)
+bool QMLStockProductCategoryModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLStockProductCategoryModel::processResult(const QueryResult &result)
 {
     if (result.request().receiver() != this)
         return;

--- a/src/rrcore/qmlapi/qmlstockproductcategorymodel.h
+++ b/src/rrcore/qmlapi/qmlstockproductcategorymodel.h
@@ -37,7 +37,8 @@ signals:
     void productFilterTextChanged();
 protected:
     void tryQuery() override final;
-    void processResult(const QueryResult result) override final;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
     void filter() override final;
 private:
     Utility::StockProductCategoryList m_categories;

--- a/src/rrcore/qmlapi/qmlstockproductmodel.cpp
+++ b/src/rrcore/qmlapi/qmlstockproductmodel.cpp
@@ -193,7 +193,13 @@ void QMLStockProductModel::tryQuery()
     }
 }
 
-void QMLStockProductModel::processResult(const QueryResult result)
+bool QMLStockProductModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLStockProductModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlstockproductmodel.h
+++ b/src/rrcore/qmlapi/qmlstockproductmodel.h
@@ -62,7 +62,8 @@ signals:
     void productRemoved(int productId);
 protected:
     void tryQuery() override final;
-    void processResult(const QueryResult result) override final;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
     QString columnName(int column) const override final;
     void filter() override final;
 public slots:

--- a/src/rrcore/qmlapi/qmlstockreportmodel.cpp
+++ b/src/rrcore/qmlapi/qmlstockreportmodel.cpp
@@ -125,7 +125,13 @@ void QMLStockReportModel::tryQuery()
                                                  this));
 }
 
-void QMLStockReportModel::processResult(const QueryResult result)
+bool QMLStockReportModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLStockReportModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlstockreportmodel.h
+++ b/src/rrcore/qmlapi/qmlstockreportmodel.h
@@ -41,7 +41,8 @@ public:
                         int role = Qt::DisplayRole) const override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override final;
+    void processResult(const QueryResult &result) override final;
 private:
     Utility::StockReportTransactionList m_transactions;
 };

--- a/src/rrcore/qmlapi/qmlusermodel.cpp
+++ b/src/rrcore/qmlapi/qmlusermodel.cpp
@@ -117,7 +117,13 @@ void QMLUserModel::tryQuery()
                                           this));
 }
 
-void QMLUserModel::processResult(const QueryResult result)
+bool QMLUserModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLUserModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmlusermodel.h
+++ b/src/rrcore/qmlapi/qmlusermodel.h
@@ -63,7 +63,8 @@ signals:
     void keysChanged();
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override;
 private:
     Utility::UserList m_users;
     int m_keys;

--- a/src/rrcore/qmlapi/qmluserprivilegemodel.cpp
+++ b/src/rrcore/qmlapi/qmluserprivilegemodel.cpp
@@ -238,7 +238,13 @@ void QMLUserPrivilegeModel::tryQuery()
                                                     this));
 }
 
-void QMLUserPrivilegeModel::processResult(const QueryResult result)
+bool QMLUserPrivilegeModel::canProcessResult(const QueryResult &result) const
+{
+    Q_UNUSED(result)
+    return true;
+}
+
+void QMLUserPrivilegeModel::processResult(const QueryResult &result)
 {
     if (this != result.request().receiver())
         return;

--- a/src/rrcore/qmlapi/qmluserprivilegemodel.h
+++ b/src/rrcore/qmlapi/qmluserprivilegemodel.h
@@ -88,7 +88,8 @@ public slots:
     bool submit() override;
 protected:
     void tryQuery() override;
-    void processResult(const QueryResult result) override;
+    bool canProcessResult(const QueryResult &result) const override;
+    void processResult(const QueryResult &result) override;
 private:
     QStringList m_titles;
     QStringList m_privilegeGroups;

--- a/src/rrcore/utility/purchase/purchasedproduct.cpp
+++ b/src/rrcore/utility/purchase/purchasedproduct.cpp
@@ -4,12 +4,37 @@ using namespace Utility;
 
 PurchasedProduct::PurchasedProduct(int id,
                                    int purchaseTransactionId) :
-    id(id)
-{
-    Q_UNUSED(purchaseTransactionId)
-}
+    id(id),
+    transaction(PurchaseTransaction{ purchaseTransactionId })
+{}
 
-PurchasedProduct::PurchasedProduct(const QVariantMap &map)
+PurchasedProduct::PurchasedProduct(const QVariantMap &map) :
+    id(map.value("purchased_product_id").toInt()),
+    transaction(PurchaseTransaction{ map.value("purchase_transaction_id").toInt() }),
+    category(StockProductCategory{ map }),
+    product(StockProduct{ map }),
+    monies(PurchaseMonies{ map }),
+    flags(map.value("archived").toBool() ? RecordGroup::Archived : RecordGroup::None),
+    note(Note{ map }),
+    timestamp(RecordTimestamp{ map }),
+    user(User{ map })
+{}
+
+QVariantMap PurchasedProduct::toVariantMap() const
 {
-    Q_UNUSED(map)
+    return {
+        { "purchased_product_id", id },
+        { "purchase_transaction_id", transaction.id },
+        { "product_category_id", category.id },
+        { "product_category", category.category },
+        { "product_id", product.id },
+        { "product", product.product },
+        { "cost", monies.cost.toDouble() },
+        { "discount", monies.discount.toDouble() },
+        { "archived", flags.testFlag(RecordGroup::Archived) },
+        { "note_id", note.id },
+        { "note", note.note },
+        { "user_id", user.id },
+        { "user", user.user }
+    };
 }

--- a/src/rrcore/utility/purchase/purchasedproduct.h
+++ b/src/rrcore/utility/purchase/purchasedproduct.h
@@ -1,12 +1,13 @@
 #ifndef PURCHASEDPRODUCT_H
 #define PURCHASEDPRODUCT_H
 
-#include "utility/stock/stockproductcategory.h"
-#include "utility/stock/stockproduct.h"
 #include "utility/common/note.h"
 #include "utility/common/recordgroup.h"
-#include "utility/user/user.h"
+#include "utility/common/recordtimestamp.h"
 #include "utility/purchase/purchasetransaction.h"
+#include "utility/stock/stockproduct.h"
+#include "utility/stock/stockproductcategory.h"
+#include "utility/user/user.h"
 #include <QVariantList>
 
 namespace Utility {
@@ -16,13 +17,11 @@ struct PurchasedProduct
     PurchaseTransaction transaction;
     StockProductCategory category;
     StockProduct product;
-    double cost {0.0};
-    double discount {0.0};
-    Note note;
-    QDateTime created;
-    QDateTime lastEdited;
-    User user;
+    PurchaseMonies monies;
     RecordGroup::Flags flags;
+    Note note;
+    RecordTimestamp timestamp;
+    User user;
     int row {-1};
 
     explicit PurchasedProduct() = default;

--- a/src/rrcore/utility/purchase/purchasetransaction.cpp
+++ b/src/rrcore/utility/purchase/purchasetransaction.cpp
@@ -28,6 +28,10 @@ PurchaseTransaction::PurchaseTransaction(const QVariantMap &transaction) :
     flags.setFlag(RecordGroup::Archived, transaction.value("archived").toBool());
 }
 
+PurchaseTransaction::PurchaseTransaction(int id) :
+    id(id)
+{}
+
 PurchaseTransaction::PurchaseTransaction(int id,
                                          const Vendor &vendor,
                                          const PurchaseMonies &monies,

--- a/src/rrcore/utility/purchase/purchasetransaction.h
+++ b/src/rrcore/utility/purchase/purchasetransaction.h
@@ -24,6 +24,7 @@ struct PurchaseTransaction {
     int row {-1};
 
     explicit PurchaseTransaction() = default;
+    explicit PurchaseTransaction(int id);
     explicit PurchaseTransaction(int id,
                                  const Vendor &vendor,
                                  const PurchaseMonies &monies,


### PR DESCRIPTION
Introduce AbstractVisualListModel::canProcessResult() and
AbstractVisualTableModel::canProcessResult() to ensure the correct
results are returned. There is a call to "qFatal" (which would crash the
application) if the proper results are not returned. This ensures that
these issues are caught during integration testing.